### PR TITLE
Fix use of test_broken on Julia 1.10

### DIFF
--- a/.github/workflows/blue_style_formatter.yml
+++ b/.github/workflows/blue_style_formatter.yml
@@ -13,7 +13,7 @@ jobs:
           version: 1
       - run: |
           julia  -e 'using Pkg; Pkg.add("JuliaFormatter")'
-          julia  -e 'using JuliaFormatter; format(".", BlueStyle(); verbose=true)'
+          julia  -e 'using JuliaFormatter; format(".", BlueStyle(); verbose=true, ignore=["test/runtests.jl"])'
       - uses: reviewdog/action-suggester@v1
         with:
           tool_name: JuliaFormatter

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1311,12 +1311,21 @@ end
                                     any(T -> data isa T, binary_not_implemented_types) ||
                                     any(occursin.(binary_not_implemented_pgtypes, test_str))
                                 )
-                                    @test_broken parsed = func(LibPQ.PQValue{oid}(result, 1, 1))
-                                    @test_broken isequal(parsed, data)
-                                    @test_broken typeof(parsed) == typeof(data)
-                                    @test_broken parsed_no_oid = func(LibPQ.PQValue(result, 1, 1))
-                                    @test_broken isequal(parsed_no_oid, data)
-                                    @test_broken typeof(parsed_no_oid) == typeof(data)
+                                    # this allows us to not care whether we error in the func call or in the tests, considering those both successful breaks
+                                    # an error will pass the outer @test_broken and skip the rest
+                                    @test_broken let
+                                        parsed = func(LibPQ.PQValue{oid}(result, 1, 1))
+                                        @test_broken isequal(parsed, data)
+                                        @test_broken typeof(parsed) == typeof(data)
+                                        # Julia 1.10+ requires @test_broken receive a boolean
+                                        false
+                                    end
+                                    @test_broken let
+                                        parsed_no_oid = func(LibPQ.PQValue(result, 1, 1))
+                                        @test_broken isequal(parsed_no_oid, data)
+                                        @test_broken typeof(parsed_no_oid) == typeof(data)
+                                        false
+                                    end
                                 else
                                     parsed = func(LibPQ.PQValue{oid}(result, 1, 1))
                                     @test isequal(parsed, data)
@@ -1389,9 +1398,15 @@ end
                                     any(T -> data isa T, binary_not_implemented_types) ||
                                     any(occursin.(binary_not_implemented_pgtypes, test_str))
                                 )
-                                    @test_broken parsed = func(LibPQ.PQValue{oid}(result, 1, 1))
-                                    @test_broken parsed == data
-                                    @test_broken typeof(parsed) == typeof(data)
+                                    # this allows us to not care whether we error in the func call or in the tests, considering those both successful breaks
+                                    # an error will pass the outer @test_broken and skip the rest
+                                    @test_broken let
+                                        parsed = func(LibPQ.PQValue{oid}(result, 1, 1))
+                                        @test_broken parsed == data
+                                        @test_broken typeof(parsed) == typeof(data)
+                                        # Julia 1.10+ requires @test_broken receive a boolean
+                                        false
+                                    end
                                 else
                                     parsed = func(LibPQ.PQValue{oid}(result, 1, 1))
                                     @test parsed == data


### PR DESCRIPTION
Julia 1.10 was failing tests before this.

There may have been issues with the value of `parsed` being reused in the loop, so they're in a `let` block now, and an error in the `func` call will skip the tests that depend on it. It's a bit hacky but I believe this is all using standard behaviour for tests, and it tests the behaviour it needs to test.